### PR TITLE
Use up-to-date interface in a template

### DIFF
--- a/pkg/template/output.go
+++ b/pkg/template/output.go
@@ -18,7 +18,7 @@ type Output struct {
 	logger          logrus.FieldLogger
 }
 
-var _ output.Output = new(Output)
+var _ output.WithStopWithTestError = new(Output)
 
 // New creates an instance of the collector
 func New(p output.Params) (*Output, error) {
@@ -39,11 +39,19 @@ func (o *Output) Description() string {
 	return "template: " + o.config.Address
 }
 
-// Stop flushes all remaining metrics and finalizes the test run
+// Stop to satisfy old output.Output interface
+// it's deprecated and will be removed in the future
+// StopWithTestError will be used instead
 func (o *Output) Stop() error {
+	return o.StopWithTestError(nil)
+}
+
+// StopWithTestError flushes all remaining metrics and finalizes the test run
+func (o *Output) StopWithTestError(testErr error) error {
 	o.logger.Debug("Stopping...")
 	defer o.logger.Debug("Stopped!")
 	o.periodicFlusher.Stop()
+
 	return nil
 }
 


### PR DESCRIPTION
# What?

During the review of the open telemetry output, we figured out the actual output. Since the output interface is deprecated, this PR switches the template to use the right one.

Related discussion: https://github.com/grafana/xk6-output-opentelemetry/pull/3#discussion_r1601877169

We probably also need to mark the interface Deprecated inside k6, but it's a bit more work since it's embedding + and not all our own output implements it yet.

# Why?

Otherwise, we could produce more extensions that implement only a legacy interface.