### PR TITLE
chore: align go directive and toolchain to 1.25.0 / 1.25.11

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: 1.21.x
+          go-version: 1.25.x
           cache: false
       - name: Check build
         run: |

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/xk6-output-template
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.25.11
 
 require (
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
## Summary
Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.

## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes